### PR TITLE
Use non-specific contract names

### DIFF
--- a/alphabet/config.yml
+++ b/alphabet/config.yml
@@ -1,4 +1,4 @@
-name: "FrostFS Alphabet"
+name: "Alphabet"
 safemethods: ["gas", "neo", "name", "version"]
 permissions:
   - methods: ["update", "transfer", "vote"]

--- a/audit/config.yml
+++ b/audit/config.yml
@@ -1,4 +1,4 @@
-name: "FrostFS Audit"
+name: "Audit"
 safemethods: ["get", "list", "listByEpoch", "listByCID", "listByNode", "version"]
 permissions:
   - methods: ["update"]

--- a/balance/config.yml
+++ b/balance/config.yml
@@ -1,4 +1,4 @@
-name: "FrostFS Balance"
+name: "Balance"
 supportedstandards: ["NEP-17"]
 safemethods: ["balanceOf", "decimals", "symbol", "totalSupply", "version"]
 permissions:

--- a/container/config.yml
+++ b/container/config.yml
@@ -1,4 +1,4 @@
-name: "FrostFS Container"
+name: "Container"
 safemethods: ["count", "containersOf", "get", "owner", "list", "eACL", "getContainerSize", "listContainerSizes", "iterateContainerSizes", "version"]
 permissions:
   - methods: ["update", "addKey", "transferX",

--- a/frostfsid/config.yml
+++ b/frostfsid/config.yml
@@ -1,4 +1,4 @@
-name: "FrostFS ID"
+name: "Identity"
 safemethods: ["key", "version"]
 permissions:
   - methods: ["update"]

--- a/netmap/config.yml
+++ b/netmap/config.yml
@@ -1,4 +1,4 @@
-name: "FrostFS Netmap"
+name: "Netmap"
 safemethods: ["innerRingList", "epoch", "netmap", "netmapCandidates", "snapshot", "snapshotByEpoch", "config", "listConfig", "version"]
 permissions:
   - methods: ["update", "newEpoch"]

--- a/processing/config.yml
+++ b/processing/config.yml
@@ -1,4 +1,4 @@
-name: "FrostFS Multi Signature Processing"
+name: "Multi Signature Processing"
 safemethods: ["verify", "version"]
 permissions:
   - methods: ["update"]

--- a/proxy/config.yml
+++ b/proxy/config.yml
@@ -1,4 +1,4 @@
-name: "FrostFS Notary Proxy"
+name: "Notary Proxy"
 safemethods: ["verify", "version"]
 permissions:
   - methods: ["update"]

--- a/reputation/config.yml
+++ b/reputation/config.yml
@@ -1,4 +1,4 @@
-name: "FrostFS Reputation"
+name: "Reputation"
 safemethods: ["get", "getByID", "listByEpoch"]
 permissions:
   - methods: ["update"]

--- a/subnet/config.yml
+++ b/subnet/config.yml
@@ -1,4 +1,4 @@
-name: "FrostFS Subnet"
+name: "Subnet"
 safemethods: ["version"]
 permissions:
   - methods: ["update"]


### PR DESCRIPTION
Allows easier project name updates in the future.